### PR TITLE
Make sure :protocol pseudoheader is added after all other pseudo-headers

### DIFF
--- a/lws_client.sh
+++ b/lws_client.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./gradlew netty-websocket-http2-example:runLwsClient

--- a/netty-websocket-http2-example/build.gradle
+++ b/netty-websocket-http2-example/build.gradle
@@ -36,3 +36,8 @@ task runChannelClient(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = "com.jauntsdn.netty.handler.codec.http2.websocketx.example.channelclient.Main"
 }
+
+task runLwsClient(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = "com.jauntsdn.netty.handler.codec.http2.websocketx.example.lwsclient.Main"
+}

--- a/netty-websocket-http2-example/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/example/lwsclient/Main.java
+++ b/netty-websocket-http2-example/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/example/lwsclient/Main.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 - present Maksym Ostroverkhov.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jauntsdn.netty.handler.codec.http2.websocketx.example.lwsclient;
+
+import static io.netty.channel.ChannelHandler.Sharable;
+
+import com.jauntsdn.netty.handler.codec.http2.websocketx.Http2WebSocketClientHandler;
+import com.jauntsdn.netty.handler.codec.http2.websocketx.Http2WebSocketClientHandshaker;
+import com.jauntsdn.netty.handler.codec.http2.websocketx.example.Security;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketDecoderConfig;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ScheduledFuture;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Main {
+  private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+  public static void main(String[] args) throws Exception {
+    String host = System.getProperty("HOST", "libwebsockets.org");
+    int port = Integer.parseInt(System.getProperty("PORT", "443"));
+    InetSocketAddress address = new InetSocketAddress(host, port);
+
+    logger.info("\n==> libwebsockets.org websocket-over-http2 client\n");
+    logger.info("\n==> Remote address: {}:{}", host, port);
+    logger.info("\n==> Dumb increment demo of https://libwebsockets.org/testserver/");
+
+    final SslContext sslContext = Security.clientSslContext();
+    Channel channel =
+        new Bootstrap()
+            .group(new NioEventLoopGroup())
+            .channel(NioSocketChannel.class)
+            .handler(
+                new ChannelInitializer<SocketChannel>() {
+                  @Override
+                  protected void initChannel(SocketChannel ch) {
+                    SslHandler sslHandler = sslContext.newHandler(ch.alloc());
+                    Http2FrameCodecBuilder http2FrameCodecBuilder =
+                        Http2FrameCodecBuilder.forClient();
+                    http2FrameCodecBuilder.initialSettings().initialWindowSize(1_000);
+                    Http2FrameCodec http2FrameCodec = http2FrameCodecBuilder.build();
+                    Http2WebSocketClientHandler http2WebSocketClientHandler =
+                        Http2WebSocketClientHandler.builder()
+                            .decoderConfig(
+                                WebSocketDecoderConfig.newBuilder()
+                                    .allowExtensions(true)
+                                    .allowMaskMismatch(true)
+                                    .build())
+                            .handshakeTimeoutMillis(15_000)
+                            .compression(true)
+                            .build();
+
+                    ch.pipeline().addLast(sslHandler, http2FrameCodec, http2WebSocketClientHandler);
+                  }
+                })
+            .connect(address)
+            .sync()
+            .channel();
+
+    Http2WebSocketClientHandshaker handShaker = Http2WebSocketClientHandshaker.create(channel);
+
+    Http2Headers headers =
+        new DefaultHttp2Headers().set("user-agent", "jauntsdn-websocket-http2-client/0.1.0");
+    ChannelFuture handshake =
+        handShaker.handshake(
+            "/", "dumb-increment-protocol", headers, new WebSocketDumbIncrementHandler());
+
+    handshake.addListener(new WebSocketFutureListener());
+
+    Channel echoWebSocketChannel = handshake.channel();
+
+    EventLoopGroup eventLoop = echoWebSocketChannel.eventLoop();
+
+    echoWebSocketChannel.closeFuture().sync();
+    logger.info("==> Websocket closed. Terminating client...");
+    eventLoop.shutdownGracefully();
+    logger.info("==> Client terminated");
+  }
+
+  @Sharable
+  private static class WebSocketDumbIncrementHandler
+      extends SimpleChannelInboundHandler<TextWebSocketFrame> {
+    private ScheduledFuture<?> sendResetFuture;
+    private ScheduledFuture<?> receiveReportFuture;
+    private int receiveCounter;
+    private int receiveValue;
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+      sendResetFuture =
+          ctx.executor()
+              .scheduleAtFixedRate(
+                  () -> {
+                    ctx.writeAndFlush(new TextWebSocketFrame("reset\n"));
+                    logger.info("==> Sent reset counter websocket frame");
+                  },
+                  5_000,
+                  5_000,
+                  TimeUnit.MILLISECONDS);
+
+      receiveReportFuture =
+          ctx.executor()
+              .scheduleAtFixedRate(
+                  () ->
+                      logger.info(
+                          "==> Received {} frames, latest value: {}", receiveCounter, receiveValue),
+                  1_000,
+                  1_000,
+                  TimeUnit.MILLISECONDS);
+
+      super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+      sendResetFuture.cancel(true);
+      receiveReportFuture.cancel(true);
+      super.channelInactive(ctx);
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, TextWebSocketFrame webSocketFrame) {
+      receiveValue = Integer.parseInt(webSocketFrame.text());
+      receiveCounter++;
+    }
+  }
+
+  private static class WebSocketFutureListener
+      implements GenericFutureListener<Future<? super Void>> {
+    @Override
+    public void operationComplete(Future<? super Void> future) {
+      if (future.isSuccess()) {
+        logger.info("==> Websocket channel future success");
+      } else {
+        logger.info("==> Websocket channel future error: {}", future.cause().toString());
+      }
+    }
+  }
+}

--- a/netty-websocket-http2/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/Http2WebSocketClientHandshaker.java
+++ b/netty-websocket-http2/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/Http2WebSocketClientHandshaker.java
@@ -382,17 +382,18 @@ public final class Http2WebSocketClientHandshaker {
     int streamId = streamIdFactory.incrementAndGetNextStreamId();
     webSocketsParent.register(streamId, webSocketChannel.setStreamId(streamId));
 
-    String path = webSocketChannel.path();
     String authority = authority();
+    String path = webSocketChannel.path();
     Http2Headers headers =
-        Http2WebSocketProtocol.extendedConnect()
-            .scheme(scheme)
-            .authority(authority)
-            .path(path)
-            /* sec-websocket-version=13 only */
-            .set(
-                Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_NAME,
-                Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_VALUE);
+        Http2WebSocketProtocol.extendedConnect(
+            new DefaultHttp2Headers()
+                .scheme(scheme)
+                .authority(authority)
+                .path(path)
+                /* sec-websocket-version=13 only */
+                .set(
+                    Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_NAME,
+                    Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_VALUE));
 
     /*compression*/
     PerMessageDeflateClientExtensionHandshaker handshaker = compressionHandshaker;

--- a/netty-websocket-http2/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/Http2WebSocketProtocol.java
+++ b/netty-websocket-http2/src/main/java/com/jauntsdn/netty/handler/codec/http2/websocketx/Http2WebSocketProtocol.java
@@ -16,7 +16,6 @@
 
 package com.jauntsdn.netty.handler.codec.http2.websocketx;
 
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
 
@@ -38,8 +37,8 @@ final class Http2WebSocketProtocol {
   static final AsciiString HEADER_PROTOCOL_NAME_HANDSHAKED = AsciiString.of("x-protocol");
   static final AsciiString HEADER_METHOD_CONNECT_HANDSHAKED = AsciiString.of("POST");
 
-  static Http2Headers extendedConnect() {
-    return new DefaultHttp2Headers()
+  static Http2Headers extendedConnect(Http2Headers headers) {
+    return headers
         .method(Http2WebSocketProtocol.HEADER_METHOD_CONNECT)
         .set(
             Http2WebSocketProtocol.HEADER_PROTOCOL_NAME,

--- a/netty-websocket-http2/src/test/java/com/jauntsdn/netty/handler/codec/http2/websocketx/ProtocolHandshakeTest.java
+++ b/netty-websocket-http2/src/test/java/com/jauntsdn/netty/handler/codec/http2/websocketx/ProtocolHandshakeTest.java
@@ -196,7 +196,7 @@ public class ProtocolHandshakeTest extends AbstractTest {
 
   static Stream<Http2Headers> invalidWebSocketRequests() {
     Http2Headers emptyPath =
-        Http2WebSocketProtocol.extendedConnect()
+        Http2WebSocketProtocol.extendedConnect(new DefaultHttp2Headers())
             .scheme("https")
             .authority("localhost")
             .path("")
@@ -206,7 +206,7 @@ public class ProtocolHandshakeTest extends AbstractTest {
                 Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_VALUE);
 
     Http2Headers emptyAuthority =
-        Http2WebSocketProtocol.extendedConnect()
+        Http2WebSocketProtocol.extendedConnect(new DefaultHttp2Headers())
             .scheme("https")
             .authority("")
             .path("path")
@@ -216,7 +216,7 @@ public class ProtocolHandshakeTest extends AbstractTest {
                 Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_VALUE);
 
     Http2Headers emptyScheme =
-        Http2WebSocketProtocol.extendedConnect()
+        Http2WebSocketProtocol.extendedConnect(new DefaultHttp2Headers())
             .scheme("")
             .authority("localhost")
             .path("path")
@@ -226,7 +226,7 @@ public class ProtocolHandshakeTest extends AbstractTest {
                 Http2WebSocketProtocol.HEADER_WEBSOCKET_VERSION_VALUE);
 
     Http2Headers nonHttpScheme =
-        Http2WebSocketProtocol.extendedConnect()
+        Http2WebSocketProtocol.extendedConnect(new DefaultHttp2Headers())
             .scheme("ftp")
             .authority("localhost")
             .path("path")


### PR DESCRIPTION
Make sure :protocol pseudoheader is added last, otherwise some implementations (e.g. libwebsockets based server) force close connection

add libwebsockets.org/testserver/ client example